### PR TITLE
Make Wink route prefix configurable

### DIFF
--- a/config/wink.php
+++ b/config/wink.php
@@ -22,4 +22,15 @@ return [
     */
 
     'storage_disk' => env('WINK_STORAGE_DISK', 'local'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wink Route Prefix
+    |--------------------------------------------------------------------------
+    | This is the prefix used for all Wink routes. By default, you can access
+    | the Wink administration at "/wink/". However, you can change that to
+    | anything you want.
+    */
+
+    'route_prefix' => env('WINK_ROUTE_PREFIX', 'wink'),
 ];

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -32,10 +32,12 @@ class WinkServiceProvider extends ServiceProvider
      */
     private function registerRoutes()
     {
+        $prefix = config('wink.route_prefix');
+
         Route::namespace('Wink\Http\Controllers')
             ->middleware('web')
             ->as('wink.')
-            ->prefix('wink')
+            ->prefix($prefix)
             ->group(function () {
                 Route::get('/login', 'LoginController@showLoginForm')->name('auth.login');
                 Route::post('/login', 'LoginController@login')->name('auth.attempt');
@@ -48,7 +50,7 @@ class WinkServiceProvider extends ServiceProvider
         Route::namespace('Wink\Http\Controllers')
             ->middleware(['web', Authenticate::class])
             ->as('wink.')
-            ->prefix('wink')
+            ->prefix($prefix)
             ->group(function () {
                 $this->loadRoutesFrom(__DIR__.'/Http/routes.php');
             });


### PR DESCRIPTION
This PR allows devs to modify the default `wink` route prefix to anything they wish via the `wink.route_prefix` config variable.

For example, you could access the Wink admin panel at `/admin/` instead of the default `/wink/`.