### PR TITLE
Make Wink use Laravel default database connection

### DIFF
--- a/config/wink.php
+++ b/config/wink.php
@@ -11,7 +11,7 @@ return [
     | to anything you want.
     */
 
-    'database_connection' => env('WINK_DB_CONNECTION', 'wink'),
+    'database_connection' => env('DB_CONNECTION', 'wink'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Hey @themsaid :) Finally managed to have some time to test it. I like it!

I am a fan of perfect installation procedures, and I think the devil is in the details :) Just tried to execute migrations using the `artisan wink:migrate` command, but I stumbled upon the "wink database connection not found". That happens because "WINK_DB_CONNECTION" is undefined by default, so we use the "wink" fallback string.

I suggest switching to the default DB_CONNECTION one, as we know it will be likely present and we won't need to add it (https://github.com/laravel/laravel/blob/master/.env.example#L9).

What do you think?