### PR TITLE
Image upload with any filesystem

### DIFF
--- a/src/Http/Controllers/ImageUploadsController.php
+++ b/src/Http/Controllers/ImageUploadsController.php
@@ -2,6 +2,8 @@
 
 namespace Wink\Http\Controllers;
 
+use Illuminate\Support\Facades\Storage;
+
 class ImageUploadsController
 {
     /**
@@ -11,12 +13,10 @@ class ImageUploadsController
      */
     public function upload()
     {
-        $path = str_replace('public/', 'storage/',
-            request()->image->store('/public/wink/images', config('wink.storage_disk'))
-        );
+        $path = request()->image->store('public/wink/images', config('wink.storage_disk'));
 
         return response()->json([
-            'url' => '/'.$path
+            'url' => Storage::disk(config('wink.storage_disk'))->url($path)
         ]);
     }
 }


### PR DESCRIPTION
Currently, image uploading only works with the `local` driver. Using the url() method allows to use image upload with any driver, such as S3.