### PR TITLE
Persist relative paths for avatar's image and post's featured image

### DIFF
--- a/src/Http/Controllers/ImageUploadsController.php
+++ b/src/Http/Controllers/ImageUploadsController.php
@@ -11,12 +11,9 @@ class ImageUploadsController
      */
     public function upload()
     {
-        $path = str_replace('public/', 'storage/',
-            request()->image->store('/public/wink/images', config('wink.storage_disk'))
-        );
-
+        $path = request()->image->store('/public/wink/images', config('wink.storage_disk'));
         return response()->json([
-            'url' => '/'.$path
+            'url' => \Storage::disk(config('wink.storage_disk'))->url($path)
         ]);
     }
 }

--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -41,7 +41,7 @@ class WinkAuthor extends Model implements Authenticatable
      * @var bool
      */
     public $incrementing = false;
-    
+
     /**
      * The column name of the "remember me" token.
      *
@@ -132,7 +132,29 @@ class WinkAuthor extends Model implements Authenticatable
      */
     public function getAvatarAttribute($value)
     {
-        return $value ?: 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim($this->email))) . '?s=80';
+        if (is_null($value)) {
+            return 'https://secure.gravatar.com/avatar/' . md5(strtolower(trim($this->email))) . '?s=80';
+        }
+
+        return \Storage::disk(config('wink.storage_disk'))->url($value);
+    }
+
+    /**
+     * Set the authors's avatar.
+     *
+     * @param  string $value
+     * @return void
+     */
+    public function setAvatarAttribute($value)
+    {
+        if (stristr($value, 'secure.gravatar.com')) {
+            $this->attributes['avatar'] = null;
+            return;
+        }
+
+        $prefixUrl = \Storage::disk('public_dev')->getDriver()->getConfig()->get('url') .'/';
+
+        $this->attributes['avatar'] = $value ? str_replace($prefixUrl, '', $value) : null;
     }
 
     /**

--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -79,4 +79,33 @@ class WinkPost extends Model
     {
         return config('wink.database_connection');
     }
+
+    /**
+     * Get the featured image.
+     *
+     * @param  string $value
+     * @return string
+     */
+
+    public function getFeaturedImageAttribute($value)
+    {
+        if (is_null($value)) {
+            return $value;
+        }
+
+        return \Storage::disk(config('wink.storage_disk'))->url($value);
+    }
+
+    /**
+     * Set the feature image of the post
+     *
+     * @param  string $value
+     * @return void
+     */
+    public function setFeaturedImageAttribute($value)
+    {
+        $prefixUrl = \Storage::disk('public_dev')->getDriver()->getConfig()->get('url') .'/';
+
+        $this->attributes['featured_image'] = $value ? str_replace($prefixUrl, '', $value) : null;
+    }
 }


### PR DESCRIPTION
Storing relative paths in database will be beneficial in case app/blog gets migrated or storage disk is changed and the assets are moved.