### PR TITLE
Add seo modal to all sections

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3705,9 +3705,17 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_SEOModal__ = __webpack_require__("./resources/js/components/SEOModal.vue");
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_SEOModal___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__components_SEOModal__);
+
+
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
+    components: {
+        'seo-modal': __WEBPACK_IMPORTED_MODULE_0__components_SEOModal___default.a
+    },
+
     data: function data() {
         return {
             entry: null,
@@ -3715,12 +3723,23 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
             id: this.$route.params.id || 'new',
 
+            seoModalShown: false,
+
             form: {
                 errors: [],
                 working: false,
                 id: '',
                 name: '',
-                slug: ''
+                slug: '',
+                meta: {
+                    meta_description: '',
+                    opengraph_title: '',
+                    opengraph_description: '',
+                    opengraph_image: '',
+                    twitter_title: '',
+                    twitter_description: '',
+                    twitter_image: ''
+                }
             }
         };
     },
@@ -3742,6 +3761,16 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             if (_this.id != 'new') {
                 _this.form.name = response.data.entry.name;
                 _this.form.slug = response.data.entry.slug;
+
+                _this.form.meta = {
+                    meta_description: response.data.entry.meta.meta_description || '',
+                    opengraph_title: response.data.entry.meta.opengraph_title || '',
+                    opengraph_description: response.data.entry.meta.opengraph_description || '',
+                    opengraph_image: response.data.entry.meta.opengraph_image || '',
+                    twitter_title: response.data.entry.meta.twitter_title || '',
+                    twitter_description: response.data.entry.meta.twitter_description || '',
+                    twitter_image: response.data.entry.meta.twitter_image || ''
+                };
             }
 
             _this.ready = true;
@@ -3803,6 +3832,25 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
                 _this5.form.working = false;
             });
+        },
+
+
+        /**
+         * Open the SEO & Social modal.
+         */
+        seoModal: function seoModal() {
+            this.seoModalShown = true;
+        },
+
+
+        /**
+         * Close the SEO modal.
+         */
+        closeSeoModal: function closeSeoModal(_ref) {
+            var content = _ref.content;
+
+            this.seoModalShown = false;
+            this.form.meta = content;
         }
     }
 });
@@ -59850,37 +59898,6 @@ var render = function() {
                 slot: "right-side"
               },
               [
-                _vm.id != "new"
-                  ? _c(
-                      "button",
-                      {
-                        staticClass:
-                          "focus:outline-none text-light hover:text-red",
-                        on: { click: _vm.deleteTag }
-                      },
-                      [
-                        _c(
-                          "svg",
-                          {
-                            staticClass: "w-4 h-4 fill-current",
-                            attrs: {
-                              xmlns: "http://www.w3.org/2000/svg",
-                              viewBox: "0 0 20 20"
-                            }
-                          },
-                          [
-                            _c("path", {
-                              attrs: {
-                                d:
-                                  "M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"
-                              }
-                            })
-                          ]
-                        )
-                      ]
-                    )
-                  : _vm._e(),
-                _vm._v(" "),
                 _c(
                   "button",
                   {
@@ -59892,12 +59909,94 @@ var render = function() {
                         expression: "form.working"
                       }
                     ],
-                    staticClass: "py-1 px-2 btn-primary text-sm ml-6",
+                    staticClass: "py-1 px-2 btn-primary text-sm mr-6",
                     on: { click: _vm.save }
                   },
                   [_vm._v("Save")]
-                )
-              ]
+                ),
+                _vm._v(" "),
+                _c("dropdown", { staticClass: "relative mr-4" }, [
+                  _c(
+                    "button",
+                    {
+                      staticClass:
+                        "focus:outline-none text-light hover:text-primary h-8",
+                      attrs: { slot: "trigger" },
+                      slot: "trigger"
+                    },
+                    [
+                      _c(
+                        "svg",
+                        {
+                          staticClass: "w-4 h-4 fill-current mt-1",
+                          attrs: {
+                            xmlns: "http://www.w3.org/2000/svg",
+                            viewBox: "0 0 20 20"
+                          }
+                        },
+                        [
+                          _c("path", {
+                            attrs: {
+                              d:
+                                "M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"
+                            }
+                          })
+                        ]
+                      )
+                    ]
+                  ),
+                  _vm._v(" "),
+                  _c(
+                    "div",
+                    {
+                      staticClass:
+                        "bg-white border border-lighter rounded absolute z-30 whitespace-no-wrap min-w-dropdown pin-r mt-1 text-sm py-2",
+                      attrs: { slot: "content" },
+                      slot: "content"
+                    },
+                    [
+                      _c(
+                        "a",
+                        {
+                          staticClass:
+                            "no-underline text-black hover:text-primary w-full block py-2 px-4",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function($event) {
+                              $event.preventDefault()
+                              return _vm.seoModal($event)
+                            }
+                          }
+                        },
+                        [
+                          _vm._v(
+                            "\n                        SEO & Social\n                    "
+                          )
+                        ]
+                      ),
+                      _vm._v(" "),
+                      _vm.id != "new"
+                        ? _c(
+                            "a",
+                            {
+                              staticClass:
+                                "no-underline text-red w-full block py-2 px-4",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function($event) {
+                                  $event.preventDefault()
+                                  return _vm.deleteTag($event)
+                                }
+                              }
+                            },
+                            [_vm._v("Delete")]
+                          )
+                        : _vm._e()
+                    ]
+                  )
+                ])
+              ],
+              1
             )
           : _vm._e()
       ]),
@@ -60013,7 +60112,14 @@ var render = function() {
             : _vm._e()
         ],
         1
-      )
+      ),
+      _vm._v(" "),
+      _vm.seoModalShown
+        ? _c("seo-modal", {
+            attrs: { input: _vm.form.meta },
+            on: { close: _vm.closeSeoModal }
+          })
+        : _vm._e()
     ],
     1
   )

--- a/public/app.js
+++ b/public/app.js
@@ -3951,7 +3951,6 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             uploadProgress: 0,
             uploading: false,
 
-            settingsModalShown: false,
             seoModalShown: false,
 
             form: {
@@ -4107,22 +4106,6 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
                 _this6.uploading = false;
             }).catch(function (error) {});
-        },
-
-
-        /**
-         * Open the settings modal.
-         */
-        settingsModal: function settingsModal() {
-            this.settingsModalShown = true;
-        },
-
-
-        /**
-         * Close the settings modal.
-         */
-        closeSettingsModal: function closeSettingsModal() {
-            this.settingsModalShown = false;
         },
 
 

--- a/public/app.js
+++ b/public/app.js
@@ -2888,10 +2888,17 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_jquery__ = __webpack_require__("./node_modules/jquery/dist/jquery.js");
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_jquery___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_jquery__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__components_SEOModal__ = __webpack_require__("./resources/js/components/SEOModal.vue");
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__components_SEOModal___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1__components_SEOModal__);
+
 
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
+    components: {
+        'seo-modal': __WEBPACK_IMPORTED_MODULE_1__components_SEOModal___default.a
+    },
+
     data: function data() {
         return {
             ready: false,
@@ -2903,13 +2910,23 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             errors: [],
 
             settingsModalShown: false,
+            seoModalShown: false,
 
             form: {
                 errors: [],
                 id: '',
                 title: 'Page Title',
                 slug: '',
-                body: ''
+                body: '',
+                meta: {
+                    meta_description: '',
+                    opengraph_title: '',
+                    opengraph_description: '',
+                    opengraph_image: '',
+                    twitter_title: '',
+                    twitter_description: '',
+                    twitter_image: ''
+                }
             }
         };
     },
@@ -2988,6 +3005,15 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
                 this.form.title = data.title;
                 this.form.slug = data.slug;
                 this.form.body = data.body;
+                this.form.meta = {
+                    meta_description: data.meta.meta_description || '',
+                    opengraph_title: data.meta.opengraph_title || '',
+                    opengraph_description: data.meta.opengraph_description || '',
+                    opengraph_image: data.meta.opengraph_image || '',
+                    twitter_title: data.meta.twitter_title || '',
+                    twitter_description: data.meta.twitter_description || '',
+                    twitter_image: data.meta.twitter_image || ''
+                };
             }
 
             setTimeout(function () {
@@ -3013,6 +3039,25 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
          */
         closeSettingsModal: function closeSettingsModal() {
             this.settingsModalShown = false;
+        },
+
+
+        /**
+         * Open the SEO & Social modal.
+         */
+        seoModal: function seoModal() {
+            this.seoModalShown = true;
+        },
+
+
+        /**
+         * Close the SEO modal.
+         */
+        closeSeoModal: function closeSeoModal(_ref) {
+            var content = _ref.content;
+
+            this.seoModalShown = false;
+            this.form.meta = content;
         },
 
 
@@ -4022,6 +4067,14 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
          */
         settingsModal: function settingsModal() {
             this.settingsModalShown = true;
+        },
+
+
+        /**
+         * Close the settings modal.
+         */
+        closeSettingsModal: function closeSettingsModal() {
+            this.settingsModalShown = false;
         },
 
 
@@ -60193,35 +60246,6 @@ var render = function() {
                 _c(
                   "button",
                   {
-                    staticClass:
-                      "focus:outline-none text-light hover:text-primary mr-5",
-                    on: { click: _vm.settingsModal }
-                  },
-                  [
-                    _c(
-                      "svg",
-                      {
-                        staticClass: "w-4 h-4 fill-current",
-                        attrs: {
-                          xmlns: "http://www.w3.org/2000/svg",
-                          viewBox: "0 0 20 20"
-                        }
-                      },
-                      [
-                        _c("path", {
-                          attrs: {
-                            d:
-                              "M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"
-                          }
-                        })
-                      ]
-                    )
-                  ]
-                ),
-                _vm._v(" "),
-                _c(
-                  "button",
-                  {
                     directives: [
                       {
                         name: "loading",
@@ -60230,12 +60254,114 @@ var render = function() {
                         expression: "status"
                       }
                     ],
-                    staticClass: "py-1 px-2 btn-primary text-sm ml-6",
+                    staticClass: "py-1 px-2 btn-primary text-sm mr-6",
                     on: { click: _vm.save }
                   },
                   [_vm._v("Save")]
-                )
-              ]
+                ),
+                _vm._v(" "),
+                _c("dropdown", { staticClass: "relative mr-4" }, [
+                  _c(
+                    "button",
+                    {
+                      staticClass:
+                        "focus:outline-none text-light hover:text-primary h-8",
+                      attrs: { slot: "trigger" },
+                      slot: "trigger"
+                    },
+                    [
+                      _c(
+                        "svg",
+                        {
+                          staticClass: "w-4 h-4 fill-current mt-1",
+                          attrs: {
+                            xmlns: "http://www.w3.org/2000/svg",
+                            viewBox: "0 0 20 20"
+                          }
+                        },
+                        [
+                          _c("path", {
+                            attrs: {
+                              d:
+                                "M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"
+                            }
+                          })
+                        ]
+                      )
+                    ]
+                  ),
+                  _vm._v(" "),
+                  _c(
+                    "div",
+                    {
+                      staticClass:
+                        "bg-white border border-lighter rounded absolute z-30 whitespace-no-wrap min-w-dropdown pin-r mt-1 text-sm py-2",
+                      attrs: { slot: "content" },
+                      slot: "content"
+                    },
+                    [
+                      _c(
+                        "a",
+                        {
+                          staticClass:
+                            "no-underline text-black hover:text-primary w-full block py-2 px-4",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function($event) {
+                              $event.preventDefault()
+                              return _vm.settingsModal($event)
+                            }
+                          }
+                        },
+                        [
+                          _vm._v(
+                            "\n                        General Settings\n                    "
+                          )
+                        ]
+                      ),
+                      _vm._v(" "),
+                      _c(
+                        "a",
+                        {
+                          staticClass:
+                            "no-underline text-black hover:text-primary w-full block py-2 px-4",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function($event) {
+                              $event.preventDefault()
+                              return _vm.seoModal($event)
+                            }
+                          }
+                        },
+                        [
+                          _vm._v(
+                            "\n                        SEO & Social\n                    "
+                          )
+                        ]
+                      ),
+                      _vm._v(" "),
+                      _vm.id != "new"
+                        ? _c(
+                            "a",
+                            {
+                              staticClass:
+                                "no-underline text-red w-full block py-2 px-4",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function($event) {
+                                  $event.preventDefault()
+                                  return _vm.deletePage($event)
+                                }
+                              }
+                            },
+                            [_vm._v("Delete")]
+                          )
+                        : _vm._e()
+                    ]
+                  )
+                ])
+              ],
+              1
             )
           : _vm._e()
       ]),
@@ -60340,18 +60466,6 @@ var render = function() {
                 1
               ),
               _vm._v(" "),
-              _vm.id != "new"
-                ? _c(
-                    "button",
-                    {
-                      staticClass:
-                        "text-red hover:underline focus:outline-none mt-10",
-                      on: { click: _vm.deletePage }
-                    },
-                    [_vm._v("Delete this post")]
-                  )
-                : _vm._e(),
-              _vm._v(" "),
               _c("div", { staticClass: "mt-10" }, [
                 _c(
                   "button",
@@ -60368,6 +60482,13 @@ var render = function() {
               ])
             ]
           )
+        : _vm._e(),
+      _vm._v(" "),
+      _vm.seoModalShown
+        ? _c("seo-modal", {
+            attrs: { input: _vm.form.meta },
+            on: { close: _vm.closeSeoModal }
+          })
         : _vm._e()
     ],
     1

--- a/public/app.js
+++ b/public/app.js
@@ -59915,7 +59915,7 @@ var render = function() {
                   [_vm._v("Save")]
                 ),
                 _vm._v(" "),
-                _c("dropdown", { staticClass: "relative mr-4" }, [
+                _c("dropdown", { staticClass: "relative" }, [
                   _c(
                     "button",
                     {
@@ -60366,7 +60366,7 @@ var render = function() {
                   [_vm._v("Save")]
                 ),
                 _vm._v(" "),
-                _c("dropdown", { staticClass: "relative mr-4" }, [
+                _c("dropdown", { staticClass: "relative" }, [
                   _c(
                     "button",
                     {
@@ -60649,7 +60649,7 @@ var render = function() {
                   [_vm._v("Save")]
                 ),
                 _vm._v(" "),
-                _c("dropdown", { staticClass: "relative mr-4" }, [
+                _c("dropdown", { staticClass: "relative" }, [
                   _c(
                     "button",
                     {
@@ -61135,7 +61135,7 @@ var render = function() {
                     )
                   : _vm._e(),
                 _vm._v(" "),
-                _c("dropdown", { staticClass: "relative mr-4" }, [
+                _c("dropdown", { staticClass: "relative" }, [
                   _c(
                     "button",
                     {

--- a/public/app.js
+++ b/public/app.js
@@ -3837,9 +3837,17 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_SEOModal__ = __webpack_require__("./resources/js/components/SEOModal.vue");
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__components_SEOModal___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__components_SEOModal__);
+
+
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
+    components: {
+        'seo-modal': __WEBPACK_IMPORTED_MODULE_0__components_SEOModal___default.a
+    },
+
     data: function data() {
         return {
             entry: null,
@@ -3850,6 +3858,9 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             uploadProgress: 0,
             uploading: false,
 
+            settingsModalShown: false,
+            seoModalShown: false,
+
             form: {
                 errors: [],
                 working: false,
@@ -3859,7 +3870,16 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
                 email: '',
                 bio: 'I am who I\'m meant to be, this is me.',
                 avatar: '',
-                password: ''
+                password: '',
+                meta: {
+                    meta_description: '',
+                    opengraph_title: '',
+                    opengraph_description: '',
+                    opengraph_image: '',
+                    twitter_title: '',
+                    twitter_description: '',
+                    twitter_image: ''
+                }
             }
         };
     },
@@ -3916,6 +3936,15 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
                     _this3.form.email = response.data.entry.email;
                     _this3.form.bio = response.data.entry.bio;
                     _this3.form.avatar = response.data.entry.avatar;
+                    _this3.form.meta = {
+                        meta_description: response.data.entry.meta.meta_description || '',
+                        opengraph_title: response.data.entry.meta.opengraph_title || '',
+                        opengraph_description: response.data.entry.meta.opengraph_description || '',
+                        opengraph_image: response.data.entry.meta.opengraph_image || '',
+                        twitter_title: response.data.entry.meta.twitter_title || '',
+                        twitter_description: response.data.entry.meta.twitter_description || '',
+                        twitter_image: response.data.entry.meta.twitter_image || ''
+                    };
                 }
 
                 _this3.ready = true;
@@ -3985,6 +4014,33 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
                 _this6.uploading = false;
             }).catch(function (error) {});
+        },
+
+
+        /**
+         * Open the settings modal.
+         */
+        settingsModal: function settingsModal() {
+            this.settingsModalShown = true;
+        },
+
+
+        /**
+         * Open the SEO & Social modal.
+         */
+        seoModal: function seoModal() {
+            this.seoModalShown = true;
+        },
+
+
+        /**
+         * Close the SEO modal.
+         */
+        closeSeoModal: function closeSeoModal(_ref) {
+            var content = _ref.content;
+
+            this.seoModalShown = false;
+            this.form.meta = content;
         }
     }
 });
@@ -4079,68 +4135,102 @@ for (var i = 0, len = code.length; i < len; ++i) {
   revLookup[code.charCodeAt(i)] = i
 }
 
+// Support decoding URL-safe base64 strings, as Node.js does.
+// See: https://en.wikipedia.org/wiki/Base64#URL_applications
 revLookup['-'.charCodeAt(0)] = 62
 revLookup['_'.charCodeAt(0)] = 63
 
-function placeHoldersCount (b64) {
+function getLens (b64) {
   var len = b64.length
+
   if (len % 4 > 0) {
     throw new Error('Invalid string. Length must be a multiple of 4')
   }
 
-  // the number of equal signs (place holders)
-  // if there are two placeholders, than the two characters before it
-  // represent one byte
-  // if there is only one, then the three characters before it represent 2 bytes
-  // this is just a cheap hack to not do indexOf twice
-  return b64[len - 2] === '=' ? 2 : b64[len - 1] === '=' ? 1 : 0
+  // Trim off extra bytes after placeholder bytes are found
+  // See: https://github.com/beatgammit/base64-js/issues/42
+  var validLen = b64.indexOf('=')
+  if (validLen === -1) validLen = len
+
+  var placeHoldersLen = validLen === len
+    ? 0
+    : 4 - (validLen % 4)
+
+  return [validLen, placeHoldersLen]
 }
 
+// base64 is 4/3 + up to two characters of the original data
 function byteLength (b64) {
-  // base64 is 4/3 + up to two characters of the original data
-  return b64.length * 3 / 4 - placeHoldersCount(b64)
+  var lens = getLens(b64)
+  var validLen = lens[0]
+  var placeHoldersLen = lens[1]
+  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+}
+
+function _byteLength (b64, validLen, placeHoldersLen) {
+  return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
 }
 
 function toByteArray (b64) {
-  var i, j, l, tmp, placeHolders, arr
-  var len = b64.length
-  placeHolders = placeHoldersCount(b64)
+  var tmp
+  var lens = getLens(b64)
+  var validLen = lens[0]
+  var placeHoldersLen = lens[1]
 
-  arr = new Arr(len * 3 / 4 - placeHolders)
+  var arr = new Arr(_byteLength(b64, validLen, placeHoldersLen))
+
+  var curByte = 0
 
   // if there are placeholders, only get up to the last complete 4 chars
-  l = placeHolders > 0 ? len - 4 : len
+  var len = placeHoldersLen > 0
+    ? validLen - 4
+    : validLen
 
-  var L = 0
-
-  for (i = 0, j = 0; i < l; i += 4, j += 3) {
-    tmp = (revLookup[b64.charCodeAt(i)] << 18) | (revLookup[b64.charCodeAt(i + 1)] << 12) | (revLookup[b64.charCodeAt(i + 2)] << 6) | revLookup[b64.charCodeAt(i + 3)]
-    arr[L++] = (tmp >> 16) & 0xFF
-    arr[L++] = (tmp >> 8) & 0xFF
-    arr[L++] = tmp & 0xFF
+  for (var i = 0; i < len; i += 4) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 18) |
+      (revLookup[b64.charCodeAt(i + 1)] << 12) |
+      (revLookup[b64.charCodeAt(i + 2)] << 6) |
+      revLookup[b64.charCodeAt(i + 3)]
+    arr[curByte++] = (tmp >> 16) & 0xFF
+    arr[curByte++] = (tmp >> 8) & 0xFF
+    arr[curByte++] = tmp & 0xFF
   }
 
-  if (placeHolders === 2) {
-    tmp = (revLookup[b64.charCodeAt(i)] << 2) | (revLookup[b64.charCodeAt(i + 1)] >> 4)
-    arr[L++] = tmp & 0xFF
-  } else if (placeHolders === 1) {
-    tmp = (revLookup[b64.charCodeAt(i)] << 10) | (revLookup[b64.charCodeAt(i + 1)] << 4) | (revLookup[b64.charCodeAt(i + 2)] >> 2)
-    arr[L++] = (tmp >> 8) & 0xFF
-    arr[L++] = tmp & 0xFF
+  if (placeHoldersLen === 2) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 2) |
+      (revLookup[b64.charCodeAt(i + 1)] >> 4)
+    arr[curByte++] = tmp & 0xFF
+  }
+
+  if (placeHoldersLen === 1) {
+    tmp =
+      (revLookup[b64.charCodeAt(i)] << 10) |
+      (revLookup[b64.charCodeAt(i + 1)] << 4) |
+      (revLookup[b64.charCodeAt(i + 2)] >> 2)
+    arr[curByte++] = (tmp >> 8) & 0xFF
+    arr[curByte++] = tmp & 0xFF
   }
 
   return arr
 }
 
 function tripletToBase64 (num) {
-  return lookup[num >> 18 & 0x3F] + lookup[num >> 12 & 0x3F] + lookup[num >> 6 & 0x3F] + lookup[num & 0x3F]
+  return lookup[num >> 18 & 0x3F] +
+    lookup[num >> 12 & 0x3F] +
+    lookup[num >> 6 & 0x3F] +
+    lookup[num & 0x3F]
 }
 
 function encodeChunk (uint8, start, end) {
   var tmp
   var output = []
   for (var i = start; i < end; i += 3) {
-    tmp = (uint8[i] << 16) + (uint8[i + 1] << 8) + (uint8[i + 2])
+    tmp =
+      ((uint8[i] << 16) & 0xFF0000) +
+      ((uint8[i + 1] << 8) & 0xFF00) +
+      (uint8[i + 2] & 0xFF)
     output.push(tripletToBase64(tmp))
   }
   return output.join('')
@@ -4150,30 +4240,33 @@ function fromByteArray (uint8) {
   var tmp
   var len = uint8.length
   var extraBytes = len % 3 // if we have 1 byte left, pad 2 bytes
-  var output = ''
   var parts = []
   var maxChunkLength = 16383 // must be multiple of 3
 
   // go through the array every three bytes, we'll deal with trailing stuff later
   for (var i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
-    parts.push(encodeChunk(uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)))
+    parts.push(encodeChunk(
+      uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
+    ))
   }
 
   // pad the end with zeros, but make sure to not forget the extra bytes
   if (extraBytes === 1) {
     tmp = uint8[len - 1]
-    output += lookup[tmp >> 2]
-    output += lookup[(tmp << 4) & 0x3F]
-    output += '=='
+    parts.push(
+      lookup[tmp >> 2] +
+      lookup[(tmp << 4) & 0x3F] +
+      '=='
+    )
   } else if (extraBytes === 2) {
-    tmp = (uint8[len - 2] << 8) + (uint8[len - 1])
-    output += lookup[tmp >> 10]
-    output += lookup[(tmp >> 4) & 0x3F]
-    output += lookup[(tmp << 2) & 0x3F]
-    output += '='
+    tmp = (uint8[len - 2] << 8) + uint8[len - 1]
+    parts.push(
+      lookup[tmp >> 10] +
+      lookup[(tmp >> 4) & 0x3F] +
+      lookup[(tmp << 2) & 0x3F] +
+      '='
+    )
   }
-
-  parts.push(output)
 
   return parts.join('')
 }
@@ -10160,7 +10253,7 @@ module.exports = "<svg viewBox=\"0 0 18 18\">\n  <path class=\"ql-fill\" d=\"M16
 
 exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   var e, m
-  var eLen = nBytes * 8 - mLen - 1
+  var eLen = (nBytes * 8) - mLen - 1
   var eMax = (1 << eLen) - 1
   var eBias = eMax >> 1
   var nBits = -7
@@ -10173,12 +10266,12 @@ exports.read = function (buffer, offset, isLE, mLen, nBytes) {
   e = s & ((1 << (-nBits)) - 1)
   s >>= (-nBits)
   nBits += eLen
-  for (; nBits > 0; e = e * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+  for (; nBits > 0; e = (e * 256) + buffer[offset + i], i += d, nBits -= 8) {}
 
   m = e & ((1 << (-nBits)) - 1)
   e >>= (-nBits)
   nBits += mLen
-  for (; nBits > 0; m = m * 256 + buffer[offset + i], i += d, nBits -= 8) {}
+  for (; nBits > 0; m = (m * 256) + buffer[offset + i], i += d, nBits -= 8) {}
 
   if (e === 0) {
     e = 1 - eBias
@@ -10193,7 +10286,7 @@ exports.read = function (buffer, offset, isLE, mLen, nBytes) {
 
 exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
   var e, m, c
-  var eLen = nBytes * 8 - mLen - 1
+  var eLen = (nBytes * 8) - mLen - 1
   var eMax = (1 << eLen) - 1
   var eBias = eMax >> 1
   var rt = (mLen === 23 ? Math.pow(2, -24) - Math.pow(2, -77) : 0)
@@ -10226,7 +10319,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
       m = 0
       e = eMax
     } else if (e + eBias >= 1) {
-      m = (value * c - 1) * Math.pow(2, mLen)
+      m = ((value * c) - 1) * Math.pow(2, mLen)
       e = e + eBias
     } else {
       m = value * Math.pow(2, eBias - 1) * Math.pow(2, mLen)
@@ -10252,7 +10345,7 @@ exports.write = function (buffer, value, offset, isLE, mLen, nBytes) {
 /*!
  * Determine if an object is a Buffer
  *
- * @author   Feross Aboukhadijeh <feross@feross.org> <http://feross.org>
+ * @author   Feross Aboukhadijeh <https://feross.org>
  * @license  MIT
  */
 
@@ -20675,7 +20768,7 @@ return jQuery;
   var undefined;
 
   /** Used as the semantic version number. */
-  var VERSION = '4.17.10';
+  var VERSION = '4.17.11';
 
   /** Used as the size to enable large array optimizations. */
   var LARGE_ARRAY_SIZE = 200;
@@ -20939,7 +21032,7 @@ return jQuery;
   var reHasUnicode = RegExp('[' + rsZWJ + rsAstralRange  + rsComboRange + rsVarRange + ']');
 
   /** Used to detect strings that need a more robust regexp to match words. */
-  var reHasUnicodeWord = /[a-z][A-Z]|[A-Z]{2,}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9 ]/;
+  var reHasUnicodeWord = /[a-z][A-Z]|[A-Z]{2}[a-z]|[0-9][a-zA-Z]|[a-zA-Z][0-9]|[^a-zA-Z0-9 ]/;
 
   /** Used to assign default `context` object properties. */
   var contextProps = [
@@ -21885,20 +21978,6 @@ return jQuery;
       }
     }
     return result;
-  }
-
-  /**
-   * Gets the value at `key`, unless `key` is "__proto__".
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {string} key The key of the property to get.
-   * @returns {*} Returns the property value.
-   */
-  function safeGet(object, key) {
-    return key == '__proto__'
-      ? undefined
-      : object[key];
   }
 
   /**
@@ -24358,7 +24437,7 @@ return jQuery;
           if (isArguments(objValue)) {
             newValue = toPlainObject(objValue);
           }
-          else if (!isObject(objValue) || (srcIndex && isFunction(objValue))) {
+          else if (!isObject(objValue) || isFunction(objValue)) {
             newValue = initCloneObject(srcValue);
           }
         }
@@ -27279,6 +27358,22 @@ return jQuery;
         array[length] = isIndex(index, arrLength) ? oldArray[index] : undefined;
       }
       return array;
+    }
+
+    /**
+     * Gets the value at `key`, unless `key` is "__proto__".
+     *
+     * @private
+     * @param {Object} object The object to query.
+     * @param {string} key The key of the property to get.
+     * @returns {*} Returns the property value.
+     */
+    function safeGet(object, key) {
+      if (key == '__proto__') {
+        return;
+      }
+
+      return object[key];
     }
 
     /**
@@ -44048,7 +44143,7 @@ exports.default = TextBlot;
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* WEBPACK VAR INJECTION */(function(global) {/**!
  * @fileOverview Kickass library to create and place poppers near their reference elements.
- * @version 1.14.4
+ * @version 1.14.5
  * @license
  * Copyright (c) 2016 Federico Zivolo and contributors
  *
@@ -44145,7 +44240,8 @@ function getStyleComputedProperty(element, property) {
     return [];
   }
   // NOTE: 1 DOM access here
-  var css = getComputedStyle(element, null);
+  var window = element.ownerDocument.defaultView;
+  var css = window.getComputedStyle(element, null);
   return property ? css[property] : css;
 }
 
@@ -44233,7 +44329,7 @@ function getOffsetParent(element) {
   var noOffsetParent = isIE(10) ? document.body : null;
 
   // NOTE: 1 DOM access here
-  var offsetParent = element.offsetParent;
+  var offsetParent = element.offsetParent || null;
   // Skip hidden elements which don't have an offsetParent
   while (offsetParent === noOffsetParent && element.nextElementSibling) {
     offsetParent = (element = element.nextElementSibling).offsetParent;
@@ -44245,9 +44341,9 @@ function getOffsetParent(element) {
     return element ? element.ownerDocument.documentElement : document.documentElement;
   }
 
-  // .offsetParent will return the closest TD or TABLE in case
+  // .offsetParent will return the closest TH, TD or TABLE in case
   // no offsetParent is present, I hate this job...
-  if (['TD', 'TABLE'].indexOf(offsetParent.nodeName) !== -1 && getStyleComputedProperty(offsetParent, 'position') === 'static') {
+  if (['TH', 'TD', 'TABLE'].indexOf(offsetParent.nodeName) !== -1 && getStyleComputedProperty(offsetParent, 'position') === 'static') {
     return getOffsetParent(offsetParent);
   }
 
@@ -44795,7 +44891,8 @@ function getReferenceOffsets(state, popper, reference) {
  * @returns {Object} object containing width and height properties
  */
 function getOuterSizes(element) {
-  var styles = getComputedStyle(element);
+  var window = element.ownerDocument.defaultView;
+  var styles = window.getComputedStyle(element);
   var x = parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
   var y = parseFloat(styles.marginLeft) + parseFloat(styles.marginRight);
   var result = {
@@ -58467,15 +58564,18 @@ module.exports = __webpack_require__(63);
 /***/ "./node_modules/timers-browserify/main.js":
 /***/ (function(module, exports, __webpack_require__) {
 
+/* WEBPACK VAR INJECTION */(function(global) {var scope = (typeof global !== "undefined" && global) ||
+            (typeof self !== "undefined" && self) ||
+            window;
 var apply = Function.prototype.apply;
 
 // DOM APIs, for completeness
 
 exports.setTimeout = function() {
-  return new Timeout(apply.call(setTimeout, window, arguments), clearTimeout);
+  return new Timeout(apply.call(setTimeout, scope, arguments), clearTimeout);
 };
 exports.setInterval = function() {
-  return new Timeout(apply.call(setInterval, window, arguments), clearInterval);
+  return new Timeout(apply.call(setInterval, scope, arguments), clearInterval);
 };
 exports.clearTimeout =
 exports.clearInterval = function(timeout) {
@@ -58490,7 +58590,7 @@ function Timeout(id, clearFn) {
 }
 Timeout.prototype.unref = Timeout.prototype.ref = function() {};
 Timeout.prototype.close = function() {
-  this._clearFn.call(window, this._id);
+  this._clearFn.call(scope, this._id);
 };
 
 // Does not start the time, just sets up the members needed.
@@ -58518,9 +58618,17 @@ exports._unrefActive = exports.active = function(item) {
 
 // setimmediate attaches itself to the global object
 __webpack_require__("./node_modules/setimmediate/setImmediate.js");
-exports.setImmediate = setImmediate;
-exports.clearImmediate = clearImmediate;
+// On some exotic environments, it's not clear which object `setimmediate` was
+// able to install onto.  Search each possibility in the same order as the
+// `setimmediate` library.
+exports.setImmediate = (typeof self !== "undefined" && self.setImmediate) ||
+                       (typeof global !== "undefined" && global.setImmediate) ||
+                       (this && this.setImmediate);
+exports.clearImmediate = (typeof self !== "undefined" && self.clearImmediate) ||
+                         (typeof global !== "undefined" && global.clearImmediate) ||
+                         (this && this.clearImmediate);
 
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__("./node_modules/webpack/buildin/global.js")))
 
 /***/ }),
 
@@ -60297,37 +60405,6 @@ var render = function() {
                 slot: "right-side"
               },
               [
-                _vm.id != "new"
-                  ? _c(
-                      "button",
-                      {
-                        staticClass:
-                          "focus:outline-none text-light hover:text-red",
-                        on: { click: _vm.deleteAuthor }
-                      },
-                      [
-                        _c(
-                          "svg",
-                          {
-                            staticClass: "w-4 h-4 fill-current",
-                            attrs: {
-                              xmlns: "http://www.w3.org/2000/svg",
-                              viewBox: "0 0 20 20"
-                            }
-                          },
-                          [
-                            _c("path", {
-                              attrs: {
-                                d:
-                                  "M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"
-                              }
-                            })
-                          ]
-                        )
-                      ]
-                    )
-                  : _vm._e(),
-                _vm._v(" "),
                 _c(
                   "button",
                   {
@@ -60339,12 +60416,94 @@ var render = function() {
                         expression: "form.working"
                       }
                     ],
-                    staticClass: "py-1 px-2 btn-primary text-sm ml-6",
+                    staticClass: "py-1 px-2 btn-primary text-sm mr-6",
                     on: { click: _vm.save }
                   },
                   [_vm._v("Save")]
-                )
-              ]
+                ),
+                _vm._v(" "),
+                _c("dropdown", { staticClass: "relative mr-4" }, [
+                  _c(
+                    "button",
+                    {
+                      staticClass:
+                        "focus:outline-none text-light hover:text-primary h-8",
+                      attrs: { slot: "trigger" },
+                      slot: "trigger"
+                    },
+                    [
+                      _c(
+                        "svg",
+                        {
+                          staticClass: "w-4 h-4 fill-current mt-1",
+                          attrs: {
+                            xmlns: "http://www.w3.org/2000/svg",
+                            viewBox: "0 0 20 20"
+                          }
+                        },
+                        [
+                          _c("path", {
+                            attrs: {
+                              d:
+                                "M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"
+                            }
+                          })
+                        ]
+                      )
+                    ]
+                  ),
+                  _vm._v(" "),
+                  _c(
+                    "div",
+                    {
+                      staticClass:
+                        "bg-white border border-lighter rounded absolute z-30 whitespace-no-wrap min-w-dropdown pin-r mt-1 text-sm py-2",
+                      attrs: { slot: "content" },
+                      slot: "content"
+                    },
+                    [
+                      _c(
+                        "a",
+                        {
+                          staticClass:
+                            "no-underline text-black hover:text-primary w-full block py-2 px-4",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function($event) {
+                              $event.preventDefault()
+                              return _vm.seoModal($event)
+                            }
+                          }
+                        },
+                        [
+                          _vm._v(
+                            "\n                        SEO & Social\n                    "
+                          )
+                        ]
+                      ),
+                      _vm._v(" "),
+                      _vm.id != "new"
+                        ? _c(
+                            "a",
+                            {
+                              staticClass:
+                                "no-underline text-red w-full block py-2 px-4",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function($event) {
+                                  $event.preventDefault()
+                                  return _vm.deleteAuthor($event)
+                                }
+                              }
+                            },
+                            [_vm._v("Delete")]
+                          )
+                        : _vm._e()
+                    ]
+                  )
+                ])
+              ],
+              1
             )
           : _vm._e()
       ]),
@@ -60621,7 +60780,14 @@ var render = function() {
             : _vm._e()
         ],
         1
-      )
+      ),
+      _vm._v(" "),
+      _vm.seoModalShown
+        ? _c("seo-modal", {
+            attrs: { input: _vm.form.meta },
+            on: { close: _vm.closeSeoModal }
+          })
+        : _vm._e()
     ],
     1
   )

--- a/public/light.css
+++ b/public/light.css
@@ -472,12 +472,6 @@ textarea::-webkit-input-placeholder {
   opacity: .5;
 }
 
-input:-ms-input-placeholder,
-textarea:-ms-input-placeholder {
-  color: inherit;
-  opacity: .5;
-}
-
 input::-ms-input-placeholder,
 textarea::-ms-input-placeholder {
   color: inherit;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=ef427733a51dca764de7",
+    "/app.js": "/app.js?id=145ff6143cf6503e9e23",
     "/light.css": "/light.css?id=36b0faba85d5628e71bb",
     "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=48566a2049e25b01275d",
+    "/app.js": "/app.js?id=1aed29292b3c8183e28c",
     "/light.css": "/light.css?id=36b0faba85d5628e71bb",
     "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=1aed29292b3c8183e28c",
+    "/app.js": "/app.js?id=ef427733a51dca764de7",
     "/light.css": "/light.css?id=36b0faba85d5628e71bb",
     "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=145ff6143cf6503e9e23",
+    "/app.js": "/app.js?id=59e16ad92cbf4543e45f",
     "/light.css": "/light.css?id=36b0faba85d5628e71bb",
     "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
 }

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=081152cf20638f425701",
-    "/light.css": "/light.css?id=e05ad90466b4abd9315c",
+    "/app.js": "/app.js?id=48566a2049e25b01275d",
+    "/light.css": "/light.css?id=36b0faba85d5628e71bb",
     "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
 }

--- a/resources/js/screens/pages/edit.vue
+++ b/resources/js/screens/pages/edit.vue
@@ -1,7 +1,12 @@
 <script type="text/ecmascript-6">
     import $ from 'jquery';
+    import SEOModal from './../../components/SEOModal';
 
     export default {
+        components: {
+            'seo-modal': SEOModal,
+        },
+
         data() {
             return {
                 ready: false,
@@ -13,6 +18,7 @@
                 errors: [],
 
                 settingsModalShown: false,
+                seoModalShown: false,
 
                 form: {
                     errors: [],
@@ -20,6 +26,15 @@
                     title: 'Page Title',
                     slug: '',
                     body: '',
+                    meta: {
+                        meta_description: '',
+                        opengraph_title: '',
+                        opengraph_description: '',
+                        opengraph_image: '',
+                        twitter_title: '',
+                        twitter_description: '',
+                        twitter_image: '',
+                    }
                 }
             };
         },
@@ -93,6 +108,15 @@
                     this.form.title = data.title;
                     this.form.slug = data.slug;
                     this.form.body = data.body;
+                    this.form.meta = {
+                        meta_description: data.meta.meta_description || '',
+                        opengraph_title: data.meta.opengraph_title || '',
+                        opengraph_description: data.meta.opengraph_description || '',
+                        opengraph_image: data.meta.opengraph_image || '',
+                        twitter_title: data.meta.twitter_title || '',
+                        twitter_description: data.meta.twitter_description || '',
+                        twitter_image: data.meta.twitter_image || '',
+                    };
                 }
 
                 setTimeout(() => {
@@ -116,6 +140,21 @@
              */
             closeSettingsModal(){
                 this.settingsModalShown = false;
+            },
+
+            /**
+             * Open the SEO & Social modal.
+             */
+            seoModal(){
+                this.seoModalShown = true;
+            },
+
+            /**
+             * Close the SEO modal.
+             */
+            closeSeoModal({content}){
+                this.seoModalShown = false;
+                this.form.meta = content;
             },
 
 
@@ -169,13 +208,26 @@
 
 
             <div class="flex items-center" v-if="ready && entry" slot="right-side">
-                <button class="focus:outline-none text-light hover:text-primary mr-5" @click="settingsModal">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current">
-                        <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>
-                    </svg>
-                </button>
 
-                <button class="py-1 px-2 btn-primary text-sm ml-6" @click="save" v-loading="status">Save</button>
+                <button class="py-1 px-2 btn-primary text-sm mr-6" @click="save" v-loading="status">Save</button>
+
+                <dropdown class="relative mr-4">
+                    <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
+                            <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>
+                        </svg>
+                    </button>
+
+                    <div slot="content" class="bg-white border border-lighter rounded absolute z-30 whitespace-no-wrap min-w-dropdown pin-r mt-1 text-sm py-2">
+                        <a href="#" @click.prevent="settingsModal" class="no-underline text-black hover:text-primary w-full block py-2 px-4">
+                            General Settings
+                        </a>
+                        <a href="#" @click.prevent="seoModal" class="no-underline text-black hover:text-primary w-full block py-2 px-4">
+                            SEO & Social
+                        </a>
+                        <a href="#" @click.prevent="deletePage" class="no-underline text-red w-full block py-2 px-4" v-if="id != 'new'">Delete</a>
+                    </div>
+                </dropdown>
             </div>
         </page-header>
 
@@ -209,12 +261,15 @@
                 <form-errors :errors="errors.slug"></form-errors>
             </div>
 
-            <button class="text-red hover:underline focus:outline-none mt-10" @click="deletePage" v-if="id != 'new'">Delete this post</button>
-
             <div class="mt-10">
                 <button class="btn-sm btn-primary" @click="settingsModalShown = false">Done</button>
             </div>
         </modal>
+
+        <!-- SEO & Social Modal -->
+        <seo-modal v-if="seoModalShown"
+                   :input="form.meta"
+                   @close="closeSeoModal"></seo-modal>
     </div>
 </template>
 

--- a/resources/js/screens/pages/edit.vue
+++ b/resources/js/screens/pages/edit.vue
@@ -211,7 +211,7 @@
 
                 <button class="py-1 px-2 btn-primary text-sm mr-6" @click="save" v-loading="status">Save</button>
 
-                <dropdown class="relative mr-4">
+                <dropdown class="relative">
                     <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
                             <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>

--- a/resources/js/screens/posts/edit.vue
+++ b/resources/js/screens/posts/edit.vue
@@ -331,7 +331,7 @@
                 <button class="py-1 px-2 btn-primary text-sm mr-6" @click="publishingModal" v-if="!form.published">Publish</button>
                 <button class="py-1 px-2 btn-primary text-sm mr-6" @click="publishingModal" v-if="form.published">Update</button>
 
-                <dropdown class="relative mr-4">
+                <dropdown class="relative">
                     <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
                             <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>

--- a/resources/js/screens/tags/edit.vue
+++ b/resources/js/screens/tags/edit.vue
@@ -141,7 +141,7 @@
             <div class="flex items-center" v-if="ready && entry" slot="right-side">
                 <button class="py-1 px-2 btn-primary text-sm mr-6" @click="save" v-loading="form.working">Save</button>
 
-                <dropdown class="relative mr-4">
+                <dropdown class="relative">
                     <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
                             <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>

--- a/resources/js/screens/tags/edit.vue
+++ b/resources/js/screens/tags/edit.vue
@@ -1,6 +1,12 @@
 <script type="text/ecmascript-6">
 
+    import SEOModal from './../../components/SEOModal';
+
     export default {
+        components: {
+            'seo-modal': SEOModal,
+        },
+
         data() {
             return {
                 entry: null,
@@ -8,12 +14,23 @@
 
                 id: this.$route.params.id || 'new',
 
+                seoModalShown: false,
+
                 form: {
                     errors: [],
                     working: false,
                     id: '',
                     name: '',
                     slug: '',
+                    meta: {
+                        meta_description: '',
+                        opengraph_title: '',
+                        opengraph_description: '',
+                        opengraph_image: '',
+                        twitter_title: '',
+                        twitter_description: '',
+                        twitter_image: '',
+                    }
                 }
             };
         },
@@ -32,6 +49,16 @@
                 if (this.id != 'new') {
                     this.form.name = response.data.entry.name;
                     this.form.slug = response.data.entry.slug;
+
+                    this.form.meta = {
+                        meta_description: response.data.entry.meta.meta_description || '',
+                        opengraph_title: response.data.entry.meta.opengraph_title || '',
+                        opengraph_description: response.data.entry.meta.opengraph_description || '',
+                        opengraph_image: response.data.entry.meta.opengraph_image || '',
+                        twitter_title: response.data.entry.meta.twitter_title || '',
+                        twitter_description: response.data.entry.meta.twitter_description || '',
+                        twitter_image: response.data.entry.meta.twitter_image || '',
+                    }
                 }
 
                 this.ready = true;
@@ -87,7 +114,23 @@
 
                     this.form.working = false;
                 });
-            }
+            },
+
+
+            /**
+             * Open the SEO & Social modal.
+             */
+            seoModal(){
+                this.seoModalShown = true;
+            },
+
+            /**
+             * Close the SEO modal.
+             */
+            closeSeoModal({content}){
+                this.seoModalShown = false;
+                this.form.meta = content;
+            },
         }
     }
 </script>
@@ -96,13 +139,22 @@
     <div>
         <page-header>
             <div class="flex items-center" v-if="ready && entry" slot="right-side">
-                <button class="focus:outline-none text-light hover:text-red" @click="deleteTag" v-if="id != 'new'">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current">
-                        <path d="M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"/>
-                    </svg>
-                </button>
+                <button class="py-1 px-2 btn-primary text-sm mr-6" @click="save" v-loading="form.working">Save</button>
 
-                <button class="py-1 px-2 btn-primary text-sm ml-6" @click="save" v-loading="form.working">Save</button>
+                <dropdown class="relative mr-4">
+                    <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
+                            <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>
+                        </svg>
+                    </button>
+
+                    <div slot="content" class="bg-white border border-lighter rounded absolute z-30 whitespace-no-wrap min-w-dropdown pin-r mt-1 text-sm py-2">
+                        <a href="#" @click.prevent="seoModal" class="no-underline text-black hover:text-primary w-full block py-2 px-4">
+                            SEO & Social
+                        </a>
+                        <a href="#" @click.prevent="deleteTag" class="no-underline text-red w-full block py-2 px-4" v-if="id != 'new'">Delete</a>
+                    </div>
+                </dropdown>
             </div>
         </page-header>
 
@@ -138,5 +190,11 @@
                 </div>
             </div>
         </div>
+
+
+        <!-- SEO & Social Modal -->
+        <seo-modal v-if="seoModalShown"
+                   :input="form.meta"
+                   @close="closeSeoModal"></seo-modal>
     </div>
 </template>

--- a/resources/js/screens/team/edit.vue
+++ b/resources/js/screens/team/edit.vue
@@ -17,7 +17,6 @@
                 uploadProgress: 0,
                 uploading: false,
 
-                settingsModalShown: false,
                 seoModalShown: false,
 
                 form: {
@@ -166,20 +165,6 @@
                     this.uploading = false;
                 }).catch(error => {
                 });
-            },
-
-            /**
-             * Open the settings modal.
-             */
-            settingsModal(){
-                this.settingsModalShown = true;
-            },
-
-            /**
-             * Close the settings modal.
-             */
-            closeSettingsModal(){
-                this.settingsModalShown = false;
             },
 
             /**

--- a/resources/js/screens/team/edit.vue
+++ b/resources/js/screens/team/edit.vue
@@ -1,6 +1,12 @@
 <script type="text/ecmascript-6">
 
+    import SEOModal from './../../components/SEOModal';
+
     export default {
+        components: {
+            'seo-modal': SEOModal,
+        },
+
         data() {
             return {
                 entry: null,
@@ -10,6 +16,9 @@
 
                 uploadProgress: 0,
                 uploading: false,
+
+                settingsModalShown: false,
+                seoModalShown: false,
 
                 form: {
                     errors: [],
@@ -21,6 +30,15 @@
                     bio: 'I am who I\'m meant to be, this is me.',
                     avatar: '',
                     password: '',
+                    meta: {
+                        meta_description: '',
+                        opengraph_title: '',
+                        opengraph_description: '',
+                        opengraph_image: '',
+                        twitter_title: '',
+                        twitter_description: '',
+                        twitter_image: '',
+                    }
                 }
             };
         },
@@ -73,6 +91,15 @@
                         this.form.email = response.data.entry.email;
                         this.form.bio = response.data.entry.bio;
                         this.form.avatar = response.data.entry.avatar;
+                        this.form.meta = {
+                            meta_description: response.data.entry.meta.meta_description || '',
+                            opengraph_title: response.data.entry.meta.opengraph_title || '',
+                            opengraph_description: response.data.entry.meta.opengraph_description || '',
+                            opengraph_image: response.data.entry.meta.opengraph_image || '',
+                            twitter_title: response.data.entry.meta.twitter_title || '',
+                            twitter_description: response.data.entry.meta.twitter_description || '',
+                            twitter_image: response.data.entry.meta.twitter_image || '',
+                        };
                     }
 
                     this.ready = true;
@@ -140,6 +167,29 @@
                 }).catch(error => {
                 });
             },
+
+            /**
+             * Open the settings modal.
+             */
+            settingsModal(){
+                this.settingsModalShown = true;
+            },
+
+            /**
+             * Open the SEO & Social modal.
+             */
+            seoModal(){
+                this.seoModalShown = true;
+            },
+
+            /**
+             * Close the SEO modal.
+             */
+            closeSeoModal({content}){
+                this.seoModalShown = false;
+                this.form.meta = content;
+            },
+
         }
     }
 </script>
@@ -148,13 +198,23 @@
     <div>
         <page-header>
             <div class="flex items-center" v-if="ready && entry" slot="right-side">
-                <button class="focus:outline-none text-light hover:text-red" @click="deleteAuthor" v-if="id != 'new'">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current">
-                        <path d="M6 2l2-2h4l2 2h4v2H2V2h4zM3 6h14l-1 14H4L3 6zm5 2v10h1V8H8zm3 0v10h1V8h-1z"/>
-                    </svg>
-                </button>
 
-                <button class="py-1 px-2 btn-primary text-sm ml-6" @click="save" v-loading="form.working">Save</button>
+                <button class="py-1 px-2 btn-primary text-sm mr-6" @click="save" v-loading="form.working">Save</button>
+
+                <dropdown class="relative mr-4">
+                    <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
+                            <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>
+                        </svg>
+                    </button>
+
+                    <div slot="content" class="bg-white border border-lighter rounded absolute z-30 whitespace-no-wrap min-w-dropdown pin-r mt-1 text-sm py-2">
+                        <a href="#" @click.prevent="seoModal" class="no-underline text-black hover:text-primary w-full block py-2 px-4">
+                            SEO & Social
+                        </a>
+                        <a href="#" @click.prevent="deleteAuthor" class="no-underline text-red w-full block py-2 px-4" v-if="id != 'new'">Delete</a>
+                    </div>
+                </dropdown>
             </div>
         </page-header>
 
@@ -229,5 +289,10 @@
                 </div>
             </div>
         </div>
+
+        <!-- SEO & Social Modal -->
+        <seo-modal v-if="seoModalShown"
+                   :input="form.meta"
+                   @close="closeSeoModal"></seo-modal>
     </div>
 </template>

--- a/resources/js/screens/team/edit.vue
+++ b/resources/js/screens/team/edit.vue
@@ -176,6 +176,13 @@
             },
 
             /**
+             * Close the settings modal.
+             */
+            closeSettingsModal(){
+                this.settingsModalShown = false;
+            },
+
+            /**
              * Open the SEO & Social modal.
              */
             seoModal(){

--- a/resources/js/screens/team/edit.vue
+++ b/resources/js/screens/team/edit.vue
@@ -208,7 +208,7 @@
 
                 <button class="py-1 px-2 btn-primary text-sm mr-6" @click="save" v-loading="form.working">Save</button>
 
-                <dropdown class="relative mr-4">
+                <dropdown class="relative">
                     <button slot="trigger" class="focus:outline-none text-light hover:text-primary h-8">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-4 h-4 fill-current mt-1">
                             <path d="M17 16v4h-2v-4h-2v-3h6v3h-2zM1 9h6v3H1V9zm6-4h6v3H7V5zM3 0h2v8H3V0zm12 0h2v12h-2V0zM9 0h2v4H9V0zM3 12h2v8H3v-8zm6-4h2v12H9V8z"/>

--- a/src/Http/Controllers/PagesController.php
+++ b/src/Http/Controllers/PagesController.php
@@ -55,7 +55,7 @@ class PagesController
             'title' => request('title'),
             'slug' => request('slug'),
             'body' => request('body', ''),
-            'meta' => request('meta', ''),
+            'meta' => request('meta', (object) []),
         ];
 
         validator($data, [

--- a/src/Http/Controllers/PagesController.php
+++ b/src/Http/Controllers/PagesController.php
@@ -55,6 +55,7 @@ class PagesController
             'title' => request('title'),
             'slug' => request('slug'),
             'body' => request('body', ''),
+            'meta' => request('meta', ''),
         ];
 
         validator($data, [

--- a/src/Http/Controllers/TagsController.php
+++ b/src/Http/Controllers/TagsController.php
@@ -62,6 +62,7 @@ class TagsController
         $data = [
             'name' => request('name'),
             'slug' => request('slug'),
+            'meta' => request('meta', (object) []),
         ];
 
         validator($data, [

--- a/src/Http/Controllers/TeamController.php
+++ b/src/Http/Controllers/TeamController.php
@@ -65,7 +65,7 @@ class TeamController
             'email' => request('email'),
             'bio' => request('bio'),
             'avatar' => request('avatar'),
-            'meta' => request('meta'),
+            'meta' => request('meta', (object) []),
         ];
 
         validator($data, [

--- a/src/Http/Controllers/TeamController.php
+++ b/src/Http/Controllers/TeamController.php
@@ -65,6 +65,7 @@ class TeamController
             'email' => request('email'),
             'bio' => request('bio'),
             'avatar' => request('avatar'),
+            'meta' => request('meta'),
         ];
 
         validator($data, [

--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -41,13 +41,22 @@ class WinkAuthor extends Model implements Authenticatable
      * @var bool
      */
     public $incrementing = false;
-    
+
     /**
      * The column name of the "remember me" token.
      *
      * @var string
      */
     protected $rememberTokenName = 'remember_token';
+
+    /**
+     * The attributes that should be casted.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'meta' => 'array'
+    ];
 
     /**
      * The posts.

--- a/src/WinkPage.php
+++ b/src/WinkPage.php
@@ -49,6 +49,7 @@ class WinkPage extends Model
     protected $casts = [
         'id' => 'string',
         'body' => 'string',
+        'meta' => 'array',
     ];
 
     /**

--- a/src/WinkTag.php
+++ b/src/WinkTag.php
@@ -42,6 +42,15 @@ class WinkTag extends Model
     public $incrementing = false;
 
     /**
+     * The attributes that should be casted.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'meta' => 'array'
+    ];
+
+    /**
      * The posts that has the tag.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany


### PR DESCRIPTION
Following on from https://github.com/writingink/wink/pull/28#issuecomment-438559659, the SEO social/meta inputs have been added to pages, authors and tags.
Each of these are now consistent with the posts page, in that:
* a settings icon appears in the nav bar, which leads to a sub-panel menu
* the sub-panel has a link to the "SEO & Social" panel, and links to general settings if such a modal already existed (pages)
* the delete option is in the settings money, again to remain consistent with the post detail screen