### PR TITLE
Author command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ php artisan wink:author "Your Name" your.name@domain.com your-secret-password
 ```
 If you leave the password field blank, a random password will be generated for you. The slug for your author will also be automatically generated with the `str_slug()` helper function unless you specify the `--slug` option.
 
-Other available options are `--bio` and `--avatar`
+Other available options are `--bio` and `--avatar`.
 
 ## Road map
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,16 @@ Route::get('/{tag}/{slug}', 'BlogController@post');
 Route::get('/{year}/{month}/{slug}', 'BlogController@post');
 ```
 
+## Command line tools
+### Create new authors
+You can easily create new authors from the console with this command:
+```
+php artisan wink:author "Your Name" your.name@domain.com your-secret-password
+```
+If you leave the password field blank, a random password will be generated for you. The slug for your author will also be automatically generated with the `str_slug()` helper function unless you specify the `--slug` option.
+
+Other available options are `--bio` and `--avatar`
+
 ## Road map
 
 Wink is still under heavy development, I decided to ship it in this early stage so you can help me make it better, however I'm already using it to run multiple websites including my personal blog.

--- a/src/Console/AuthorCommand.php
+++ b/src/Console/AuthorCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Wink\Console;
+
+use Illuminate\Console\Command;
+use Wink\WinkAuthor;
+use Illuminate\Support\Str;
+
+class AuthorCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'wink:author {name} {email} {password?} {--bio=} {--avatar=} {--slug=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Wink Author';
+
+    /**
+     * Check if the generated Author is valid
+     *
+     * @var boolean
+     */
+    public function validate($author) {
+        $email_unique = WinkAuthor::where('email', $author['email'])->count() == 0;
+        $slug_unique = WinkAuthor::where('slug', $author['slug'])->count() == 0;
+
+        if($email_unique && $slug_unique) {
+            return true;
+        } else {
+            if(!$slug_unique) {
+                $this->error('The slug "' . $author['slug'] .'" is already in use. Please choose another one.');
+            }
+            if(!$email_unique) {
+                $this->error('The email "' . $author['email'] .'" is already in use. Please choose another one.');
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Print the generated author to the console.
+     *
+     * @var void
+     */
+    public function showResult($author) {
+        $headers = ['Property', 'Value'];
+
+        $values = [];
+        $values[] = [ 'ID', $author['id'] ];
+        $values[] = [ 'Slug', $author['slug'] ];
+        $values[] = [ 'Name', $author['name'] ];
+        $values[] = [ 'Email', $author['email'] ];
+        $values[] = [ 'Password', $this->unhashed_password ];
+        $values[] = [ 'Bio', $author['bio'] ];
+        $values[] = [ 'Avatar', $author['avatar'] ];
+
+        $this->table($headers, $values);
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $author = [
+            'id' => (string) Str::uuid(),
+            'name' => $this->argument('name'),
+            'email' => $this->argument('email'),
+        ];
+
+        // Add Slug
+        $author['slug'] = $this->option('slug') != null ? $this->option('slug') : str_slug($this->argument('name'));
+
+        // Add Bio
+        $author['bio'] = $this->option('bio') != null ? $this->option('bio') : '';
+
+        // Add Avatar
+        $author['avatar'] = $this->option('avatar');
+
+        // Add Password
+        if($this->argument('password') == null) {
+            $this->unhashed_password = str_random();
+            $this->random_password_generated = true;
+        } else {
+            $this->unhashed_password = $this->argument('password');
+        }
+        $author['password'] = \Hash::make($this->unhashed_password);
+
+        // Validate author. If it is invalid, don't save it.
+        if($this->validate($author)) {            
+            WinkAuthor::create($author);
+
+            $this->showResult($author);
+
+            if(isset($this->random_password_generated) && $this->random_password_generated == true) {
+                $this->comment('No password was given. A random password was generated for your author.');
+            }
+            $this->info('Author created!');
+        }
+    }
+}

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -118,6 +118,7 @@ class WinkServiceProvider extends ServiceProvider
         $this->commands([
             Console\InstallCommand::class,
             Console\MigrateCommand::class,
+            Console\AuthorCommand::class,
         ]);
     }
 }


### PR DESCRIPTION
When I installed Wink yesterday, there were a few errors, so no default author was created. Then I had to insert a new author directly into the database, which was quite confusing, because of the UUID and that I have to hash the password before inserting it into the database...

So I thought it would be nice to have a console command to easily create new authors from the command line, and this is what came out. 

You can now create authors this way: 
```
php artisan wink:author {name} {email} {password}
```

You can also add more information with the `--bio`, `---slug` and `--avatar` options if you want.

But I'm still unsure about the command name because it's not clear that you want to create an author with `wink:author`, it looks more like a managing tool. But I thought `wink:make:author` is a little bit too long and `make:author` doesn't match with the idea to make Wink independent from the rest of your code.