### PR TITLE
Add link to Wink logo to goto the Home route

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -56586,9 +56586,19 @@ var render = function() {
                 }
               },
               [
-                _c("span", { staticClass: "text-light" }, [_vm._v("W")]),
-                _vm._v("ink.\n                ")
-              ]
+                _c(
+                  "router-link",
+                  {
+                    staticClass: "no-underline text-black",
+                    attrs: { to: "/" }
+                  },
+                  [
+                    _c("span", { staticClass: "text-light" }, [_vm._v("W")]),
+                    _vm._v("ink.\n                    ")
+                  ]
+                )
+              ],
+              1
             ),
             _vm._v(" "),
             _vm._t("left-side")

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=7b464475e53295dcf06b",
+    "/app.js": "/app.js?id=a6b79f082c66495f198f",
     "/light.css": "/light.css?id=b412e0f37ad6832b9009",
-    "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
+    "/favicon.png": "/favicon.png?id=51f136ac7a92b2753c4e"
 }

--- a/resources/js/components/PageHeader.vue
+++ b/resources/js/components/PageHeader.vue
@@ -15,7 +15,9 @@
             <div class="flex items-center py-2">
                 <div class="flex items-center mr-auto">
                     <h3 class="mr-5 font-semibold font-serif" :class="{'hidden': hideLogoOnSmallScreens, 'sm:block': hideLogoOnSmallScreens}">
-                        <span class="text-light">W</span>ink.
+                        <router-link to="/" class="no-underline text-black">
+                            <span class="text-light">W</span>ink.
+                        </router-link>
                     </h3>
 
                     <slot name="left-side"></slot>


### PR DESCRIPTION
This PR Add convert the Wink Logo to be a link which is the expected behavior to make it easier to navigate to the Home screen (which is the Posts screen) with a single click (instead of open the Dropdown and click Posts link).