### PR TITLE
Remove .vue extension from component registration

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
     "/app.js": "/app.js?id=47e656dd2bb0b7281aeb",
     "/light.css": "/light.css?id=5c4e6e802e09bd489fc6",
-    "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
+    "/favicon.png": "/favicon.png?id=51f136ac7a92b2753c4e"
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -14,20 +14,20 @@ const router = new VueRouter({
     base: '/' + Wink.path,
 });
 
-Vue.component('page-header', require('./components/PageHeader.vue'));
-Vue.component('preloader', require('./partials/preloader.vue'));
+Vue.component('page-header', require('./components/PageHeader'));
+Vue.component('preloader', require('./partials/preloader'));
 
-Vue.component('alert', require('./components/Alert.vue'));
-Vue.component('dropdown', require('./components/DropDown.vue'));
-Vue.component('modal', require('./components/Modal.vue'));
-Vue.component('fullscreen-modal', require('./components/FullscreenModal.vue'));
-Vue.component('notification', require('./components/Notification.vue'));
-Vue.component('mini-editor', require('./components/MiniEditor.vue'));
-Vue.component('editor', require('./components/Editor.vue'));
-Vue.component('form-errors', require('./components/FormErrors.vue'));
-Vue.component('image-picker', require('./components/ImagePicker.vue'));
-Vue.component('date-time-picker', require('./components/DateTimePicker.vue'));
-Vue.component('multiselect', require('./components/MultiSelect.vue'));
+Vue.component('alert', require('./components/Alert'));
+Vue.component('dropdown', require('./components/DropDown'));
+Vue.component('modal', require('./components/Modal'));
+Vue.component('fullscreen-modal', require('./components/FullscreenModal'));
+Vue.component('notification', require('./components/Notification'));
+Vue.component('mini-editor', require('./components/MiniEditor'));
+Vue.component('editor', require('./components/Editor'));
+Vue.component('form-errors', require('./components/FormErrors'));
+Vue.component('image-picker', require('./components/ImagePicker'));
+Vue.component('date-time-picker', require('./components/DateTimePicker'));
+Vue.component('multiselect', require('./components/MultiSelect'));
 Vue.directive('loading', require('./components/loadingButton'));
 Vue.directive('click-outside', require('./components/clickOutside'));
 


### PR DESCRIPTION
Just a minor change but it seemed to be that to be consistent with directive registration we could clean a bit the component registration by removing the `.vue` extension since it is not necessary.