### PR TITLE
Fix style of Select lists in Filters Dropdown for Firefox

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -42049,7 +42049,7 @@ var render = function() {
                             }
                           ],
                           staticClass:
-                            "border border-lighter w-3/5 focus:outline-none appearance-none py-1 px-3",
+                            "border border-lighter rounded w-3/5 focus:outline-none appearance-none py-1 px-3",
                           attrs: { name: "status" },
                           on: {
                             change: function($event) {
@@ -42114,7 +42114,7 @@ var render = function() {
                             }
                           ],
                           staticClass:
-                            "border border-lighter w-3/5 focus:outline-none appearance-none py-1 px-3",
+                            "border border-lighter rounded w-3/5 focus:outline-none appearance-none py-1 px-3",
                           attrs: { name: "author" },
                           on: {
                             change: function($event) {
@@ -42172,7 +42172,7 @@ var render = function() {
                             }
                           ],
                           staticClass:
-                            "border border-lighter w-3/5 focus:outline-none appearance-none py-1 px-3",
+                            "border border-lighter rounded w-3/5 focus:outline-none appearance-none py-1 px-3",
                           attrs: { name: "tag" },
                           on: {
                             change: function($event) {

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/app.js": "/app.js?id=5e7ab16b5b12b42b7a86",
+    "/app.js": "/app.js?id=58031cda0c5be11a1b5b",
     "/light.css": "/light.css?id=5c4e6e802e09bd489fc6",
-    "/favicon.png": "/favicon.png?id=b0b34b4095fcdbb8942d"
+    "/favicon.png": "/favicon.png?id=51f136ac7a92b2753c4e"
 }

--- a/resources/js/screens/posts/index.vue
+++ b/resources/js/screens/posts/index.vue
@@ -114,7 +114,7 @@
                     <div class="flex items-center justify-between mt-5">
                         <span>Status</span>
                         <select name="status"
-                                class="border border-lighter w-3/5 focus:outline-none appearance-none py-1 px-3"
+                                class="border border-lighter rounded w-3/5 focus:outline-none appearance-none py-1 px-3"
                                 v-model="filters.status">
                             <option value="">All</option>
                             <option value="live">Live</option>
@@ -127,7 +127,7 @@
                     <div class="flex items-center justify-between mt-3">
                         <span>Author</span>
                         <select name="author"
-                                class="border border-lighter w-3/5 focus:outline-none appearance-none py-1 px-3"
+                                class="border border-lighter rounded w-3/5 focus:outline-none appearance-none py-1 px-3"
                                 v-model="filters.author_id">
                             <option value="">All</option>
                             <option v-for="author in authors" :value="author.id">{{author.name}}</option>
@@ -137,7 +137,7 @@
                     <div class="flex items-center justify-between mt-3">
                         <span>Tag</span>
                         <select name="tag"
-                                class="border border-lighter w-3/5 focus:outline-none appearance-none py-1 px-3"
+                                class="border border-lighter rounded w-3/5 focus:outline-none appearance-none py-1 px-3"
                                 v-model="filters.tag_id">
                             <option value="">All</option>
                             <option v-for="tag in tags" :value="tag.id">{{tag.name}}</option>


### PR DESCRIPTION
Make border of Select lists in Filters Dropdown rounded for Firefox to be consistent with Chrome:
![screen shot 2018-11-21 at 8 49 40 am](https://user-images.githubusercontent.com/1811607/48823814-e0e1a280-ed6a-11e8-9d92-60eca87a189d.png)

![screen shot 2018-11-21 at 8 50 07 am](https://user-images.githubusercontent.com/1811607/48823820-e63eed00-ed6a-11e8-8283-b3755c77d12b.png)
