### PR TITLE
Add published field to casts array

### DIFF
--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -55,6 +55,7 @@ class WinkPost extends AbstractWinkModel
      */
     protected $casts = [
         'meta' => 'array',
+        'published' => 'boolean',
     ];
 
     /**


### PR DESCRIPTION
Depending on how the database saves boolean columns, the published value did not evaluate correctly.
Adding the published field to the casts array fixes it.

Fixes #100