### PR TITLE
Add the option to change the middleware group.

### DIFF
--- a/config/wink.php
+++ b/config/wink.php
@@ -41,4 +41,18 @@ return [
     */
 
     'path' => env('WINK_PATH', 'wink'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wink Middleware Group
+    |--------------------------------------------------------------------------
+    |
+    | This is the middleware group that wink use.
+    | By default is the web group a correct one.
+    | It need at least the next middlewares
+    | - StartSession
+    | - ShareErrorsFromSession
+    |
+    */
+    'middleware_group' => env('WINK_MIDDLEWARE_GROUP', 'web'),
 ];

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -32,9 +32,10 @@ class WinkServiceProvider extends ServiceProvider
     private function registerRoutes()
     {
         $path = config('wink.path');
+        $middlewareGroup = config('wink.middleware_group');
 
         Route::namespace('Wink\Http\Controllers')
-            ->middleware('web')
+            ->middleware($middlewareGroup)
             ->as('wink.')
             ->prefix($path)
             ->group(function () {
@@ -47,7 +48,7 @@ class WinkServiceProvider extends ServiceProvider
             });
 
         Route::namespace('Wink\Http\Controllers')
-            ->middleware(['web', Authenticate::class])
+            ->middleware([$middlewareGroup, Authenticate::class])
             ->as('wink.')
             ->prefix($path)
             ->group(function () {


### PR DESCRIPTION
I add this config option to change the middleware group.

I found it useful if I don't need the sessions / cookies on my website except for the wink admin part. On this way I can create a new middleware group and use that for wink.