### PR TITLE
add email `exists` validation

### DIFF
--- a/src/Http/Controllers/ForgotPasswordController.php
+++ b/src/Http/Controllers/ForgotPasswordController.php
@@ -29,7 +29,7 @@ class ForgotPasswordController extends Controller
     public function sendResetLinkEmail()
     {
         validator(request()->all(), [
-            'email' => 'required|email',
+            'email' => 'required|email|exists:'.config('wink.database_connection').'.wink_authors',
         ])->validate();
 
         if ($author = WinkAuthor::whereEmail(request('email'))->first()) {


### PR DESCRIPTION
When a user's email doesn't exist in wink_author during password-reset, validation error will show up.