### PR TITLE
fix syncing existing tags to a post

### DIFF
--- a/src/Http/Controllers/PostsController.php
+++ b/src/Http/Controllers/PostsController.php
@@ -110,7 +110,7 @@ class PostsController
         $allTags = WinkTag::all();
 
         return collect($incomingTags)->map(function ($incomingTag) use ($allTags) {
-            $tag = $allTags->where('slug', Str::slug($incomingTag['name']))->first();
+            $tag = $allTags->where('id', $incomingTag['id'])->first();
 
             if (! $tag) {
                 $tag = WinkTag::create([


### PR DESCRIPTION
I have built my blog using wink, and while using it I encountered the following problem.
My blog content is in arabic so for both posts and tags I used arabic names, but for slugs I used english.

First I Added this new tag

![tag-slug-in-english](https://user-images.githubusercontent.com/31843646/59151846-66445000-8a3a-11e9-87d6-24a1020bc708.png)


Then I added a post and I wanted to attach the **tutorials** tag to it, but instead of attaching the existing tag it creates a new one.

![attach-tag-to-post](https://user-images.githubusercontent.com/31843646/59151859-9a1f7580-8a3a-11e9-82c9-40b384fb6603.png)

This is because the current code converts the tag name to slug and search if there is a tag slug with this same slug, but in my case it can`t because the slug is diffrent from the name so it creates a new tag, like the following

![creates-new-tag-with-new-slug](https://user-images.githubusercontent.com/31843646/59151892-f97d8580-8a3a-11e9-80a6-496e218b3508.png)


So in this PR I suggest instead of searching by the name slug, we search by id of the tag if it exists.

I know that Multi-lingual content is still in the future ideas which you are still not sure about, but I think this problem might be encountered even in english. 


I hope I clearly explained my issue and why I requested this PR. 
