### PR TITLE
Forces data wrapping on resources

### DIFF
--- a/src/Http/Resources/PagesResource.php
+++ b/src/Http/Resources/PagesResource.php
@@ -14,6 +14,8 @@ class PagesResource extends JsonResource
      */
     public function toArray($request)
     {
+        self::$wrap = 'data';
+
         return parent::toArray($request);
     }
 }

--- a/src/Http/Resources/PostsResource.php
+++ b/src/Http/Resources/PostsResource.php
@@ -14,6 +14,8 @@ class PostsResource extends JsonResource
      */
     public function toArray($request)
     {
+        self::$wrap = 'data';
+
         return parent::toArray($request);
     }
 }

--- a/src/Http/Resources/TagsResource.php
+++ b/src/Http/Resources/TagsResource.php
@@ -14,6 +14,8 @@ class TagsResource extends JsonResource
      */
     public function toArray($request)
     {
+        self::$wrap = 'data';
+
         return parent::toArray($request);
     }
 }

--- a/src/Http/Resources/TeamResource.php
+++ b/src/Http/Resources/TeamResource.php
@@ -14,6 +14,8 @@ class TeamResource extends JsonResource
      */
     public function toArray($request)
     {
+        self::$wrap = 'data';
+
         return parent::toArray($request);
     }
 }


### PR DESCRIPTION
This PR fixes #161 and #132. 

I would consider this issue to be an edge case since not a lot of people have reported having this issue.

## Explanation

If you had `Resource::withoutWrapping();` set in your `AppServiceProvider` boot method (like I had), then this package would not work ... (in my case I could not create posts) because all API endpoint would return without being wrapped in `data`. And then, Vue.js could not get the correct author_id in my case.

## Solution

This PR forces data wrapping on resources by adding this line:

```
self::$wrap = 'data';
```

inside the resource `toArray` method.

This solution ignores the global `Resource::withoutWrapping();` which sets `$wrap` to `null`.

This PR does not break any functionality and is completely backward compatible. No user action required.