### PR TITLE
Use the Str class and not the str_random helper

### DIFF
--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -47,7 +47,7 @@ class MigrateCommand extends Command
                 'slug' => 'regina-phalange',
                 'bio' => 'This is me.',
                 'email' => 'admin@mail.com',
-                'password' => Hash::make($password = str_random()),
+                'password' => Hash::make($password = Str::random()),
             ]);
 
             $this->line('');


### PR DESCRIPTION
Use Str::random and not str_random in the MigrateCommand

This is the only thing I found that doesn't work with Laravel 6.