### PR TITLE
Add HasSlug trait

### DIFF
--- a/src/Traits/HasSlug.php
+++ b/src/Traits/HasSlug.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Wink\Traits;
+
+trait HasSlug
+{
+    /**
+     * Find model by slug.
+     *
+     * @param string $slug
+     * @return Illuminate\Database\Eloquent\Model|null $post|null
+     */
+    public static function findBySlug($slug)
+    {
+        return static::where('slug', $slug)->first();
+    }
+}

--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -3,9 +3,12 @@
 namespace Wink;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Wink\Traits\HasSlug;
 
 class WinkAuthor extends AbstractWinkModel implements Authenticatable
 {
+    use HasSlug;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/src/WinkPage.php
+++ b/src/WinkPage.php
@@ -2,8 +2,12 @@
 
 namespace Wink;
 
+use Wink\Traits\HasSlug;
+
 class WinkPage extends AbstractWinkModel
 {
+    use HasSlug;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -5,9 +5,12 @@ namespace Wink;
 use DateTimeInterface;
 use Illuminate\Support\HtmlString;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
+use Wink\Traits\HasSlug;
 
 class WinkPost extends AbstractWinkModel
 {
+    use HasSlug;
+
     /**
      * The attributes that aren't mass assignable.
      *

--- a/src/WinkTag.php
+++ b/src/WinkTag.php
@@ -2,8 +2,12 @@
 
 namespace Wink;
 
+use Wink\Traits\HasSlug;
+
 class WinkTag extends AbstractWinkModel
 {
+    use HasSlug;
+
     /**
      * The attributes that aren't mass assignable.
      *


### PR DESCRIPTION
**PR Changes** 

This PR will allow `post`, `page`, and `author` to pull via slug easier and cleaner.

example usage

`$post = WinkPost::findBySlug($slug);` 