### PR TITLE
#288 Feature/remove featured image

### DIFF
--- a/resources/js/components/CropperModal.vue
+++ b/resources/js/components/CropperModal.vue
@@ -69,7 +69,7 @@
             },
 
             /**
-             * Upload the orginal image.
+             * Upload the original image.
              */
             uploadOriginalImage() {
                 let file = this.image;

--- a/resources/js/screens/posts/FeaturedImageUploader.vue
+++ b/resources/js/screens/posts/FeaturedImageUploader.vue
@@ -37,6 +37,14 @@
                 this.close();
             },
 
+            /**
+             *  Remove image
+             */
+            removeImage() {
+                this.imageUrl = null;
+                this.$emit('removed');
+            },
+
 
             /**
              * Close the modal.
@@ -76,7 +84,15 @@
         <preloader v-if="uploading"></preloader>
 
         <div v-if="imageUrl && !uploading">
-            <img :src="imageUrl" class="max-w-full">
+            <div class="relative">
+                <button @click="removeImage"
+                        class="btn-sm bg-red absolute pin-t pin-r border-black rounded mr-1 mt-1 h-6 w-8 bg-very-light">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+                <img :src="imageUrl" class="max-w-full">
+            </div>
 
             <div class="input-group">
                 <label class="input-label">Caption</label>

--- a/resources/js/screens/posts/edit.vue
+++ b/resources/js/screens/posts/edit.vue
@@ -272,6 +272,15 @@
 
 
             /**
+             * Handle the change event of featured images.
+             */
+            featuredImageRemoved() {
+                this.form.featured_image = null;
+                this.form.featured_image_caption = null;
+            },
+
+
+            /**
              * Close the SEO modal.
              */
             closeSeoModal({content}) {
@@ -507,6 +516,7 @@
         <!-- Featured Image Modal -->
         <featured-image-uploader :post-id="this.form.id"
                                  @changed="featuredImageChanged"
+                                 @removed="featuredImageRemoved"
                                  :current-image-url="form.featured_image"
                                  :current-caption="form.featured_image_caption"></featured-image-uploader>
     </div>


### PR DESCRIPTION
Currently, there is no functionality to remove the featured image after it gets added.
This PR adds the ability to remove the featured image without adding another image.

Fixes: https://github.com/themsaid/wink/issues/288

This is how it looks in the featured image modal.
![image](https://user-images.githubusercontent.com/5137072/94838925-ecf11d80-0433-11eb-9626-1ae9fd9a566f.png)
