### PR TITLE
Allow php8 platform within composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.3||^7.4",
+        "php": "^7.3||^7.4||^8.0",
         "laravel/framework": "^7.0||^8.0"
     },
     "autoload": {


### PR DESCRIPTION
* Adding php8 support

There doesn't seem to be any issues, I'm using it currently in a new php8 project