### PR TITLE
feature: wink:controller command that creates a sample controller to display posts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,54 @@ Wink is faceless, it doesn't have any opinions on how you display your content i
 
 To display posts and pages content, use `$post->content` instead of `$post->body`. The content will always be in HTML format while the body might be HTML or raw markdown based on the post type.
 
+## Generating a sample controller
+
+You can **generate a sample controller** by running:
+
+```sh
+php artisan wink:controller BlogController
+```
+
+This will create a file in your `Http/Controllers` directory named `BlogController.php`.  You can replace `BlogController` in the commandnoun you prefer which will prefix the file and class names  (e.g. if you use`php artisan wink:controller Post` the file and class created will be named `PostController` with any name for your controller. 
+
+The sample controller contains the following code:
+
+```angular2
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Wink\WinkPost;
+
+class BlogController extends Controller
+{
+    public function index()
+    {
+        $posts = WinkPost::with('tags')
+            ->live()
+            ->orderBy('publish_date', 'DESC')
+            ->simplePaginate(10);
+        return view('blog.index', [
+            'posts' => $posts,
+        ]);
+    }
+
+    public function show ($slug)
+    {
+        $post = WinkPost::live()->whereSlug($slug)->firstOrFail();
+
+        return view('post.index', [
+            'post' => $post
+        ]);
+    }
+}
+```
+ 
+ This mean the `index()` method will retrieve 10 published blog posts per page with their associated tags, most recent first, and render them in the `blog.index` view. You will need to create that view and the associated route.
+ 
+ The `show()` method in turn will retrieve a single published post corresponding to its slug and render it in the `post.index` view,  displaying an error message if it's not found.  You will need to create that view with the associated route,. 
+ 
 ## Credits
 
 - [Mohamed Said](https://github.com/themsaid)

--- a/src/Console/ControllerCommand.php
+++ b/src/Console/ControllerCommand.php
@@ -53,7 +53,7 @@ class ControllerCommand extends GeneratorCommand
     protected function getPath($name)
     {
         $name = str_replace($this->laravel->getNamespace(), '', $name);
-        return $this->laravel['path'].'/'.str_replace('\\', '/', $name) . '.php';
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
     }
 
     /**

--- a/src/Console/ControllerCommand.php
+++ b/src/Console/ControllerCommand.php
@@ -41,7 +41,7 @@ class ControllerCommand extends GeneratorCommand
      */
     protected function getStub()
     {
-        return __DIR__ . '/Stubs/BlogController.stub';
+        return __DIR__.'/Stubs/BlogController.stub';
     }
 
     /**
@@ -53,7 +53,7 @@ class ControllerCommand extends GeneratorCommand
     protected function getPath($name)
     {
         $name = str_replace($this->laravel->getNamespace(), '', $name);
-        return $this->laravel['path'] . '/' . str_replace('\\', '/', $name) . '.php';
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name) . '.php';
     }
 
     /**
@@ -65,7 +65,7 @@ class ControllerCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\Http\Controllers';
+        return $rootNamespace.'\Http\Controllers';
     }
 
     /**

--- a/src/Console/ControllerCommand.php
+++ b/src/Console/ControllerCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Wink\Console;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ControllerCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'wink:controller';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'wink:controller {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'creates a controller to display Laravel Wink blog posts ';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Controller';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__ . '/Stubs/BlogController.stub';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     *
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = str_replace($this->laravel->getNamespace(), '', $name);
+        return $this->laravel['path'] . '/' . str_replace('\\', '/', $name) . '.php';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Http\Controllers';
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param string $name
+     * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildClass($name)
+    {
+        $stub = $this->files->get($this->getStub());
+        return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
+    }
+}

--- a/src/Console/ControllerCommand.php
+++ b/src/Console/ControllerCommand.php
@@ -53,6 +53,7 @@ class ControllerCommand extends GeneratorCommand
     protected function getPath($name)
     {
         $name = str_replace($this->laravel->getNamespace(), '', $name);
+
         return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
     }
 
@@ -78,6 +79,7 @@ class ControllerCommand extends GeneratorCommand
     protected function buildClass($name)
     {
         $stub = $this->files->get($this->getStub());
+
         return $this->replaceNamespace($stub, $name)->replaceClass($stub, $name);
     }
 }

--- a/src/Console/Stubs/BlogController.stub
+++ b/src/Console/Stubs/BlogController.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Http\Request;
+use Wink\WinkPost;
+
+class DummyClass extends Controller
+{
+    public function index()
+    {
+        $posts = WinkPost::with('tags')
+            ->live()
+            ->orderBy('publish_date', 'DESC')
+            ->simplePaginate(12);
+        return view('blog.index', [
+            'posts' => $posts,
+        ]);
+    }
+
+    public function show ($slug)
+    {
+        $post = WinkPost::live()->whereSlug($slug)->firstOrFail();
+
+        return view('post.index', [
+            'post' => $post
+        ]);
+    }
+}

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -107,6 +107,7 @@ class WinkServiceProvider extends ServiceProvider
         $this->commands([
             Console\InstallCommand::class,
             Console\MigrateCommand::class,
+            Console\ControllerCommand::class
         ]);
     }
 }

--- a/src/WinkServiceProvider.php
+++ b/src/WinkServiceProvider.php
@@ -107,7 +107,7 @@ class WinkServiceProvider extends ServiceProvider
         $this->commands([
             Console\InstallCommand::class,
             Console\MigrateCommand::class,
-            Console\ControllerCommand::class
+            Console\ControllerCommand::class,
         ]);
     }
 }


### PR DESCRIPTION
## Summary

`php artisan wink:controller {name}` can be run alongside `wink:install` and `wink:migrate` to provide boilerplate to display wink posts.

## Implementation

- I created a console command to generate the new controller file in the main `Http/Controllers` directory, with correct filename, class and namespacing.
- I created a `Stubs` directory, and provided the required BlogController stub
- I updated the wink service provider with the new command.

## Use

You can **generate a sample controller** by running:

```sh
php artisan wink:controller BlogController
```

This will create a file in your `Http/Controllers` directory named `BlogController.php`.  You can replace `BlogController` in the commandnoun you prefer which will prefix the file and class names  (e.g. if you use`php artisan wink:controller Post` the file and class created will be named `PostController` with any name for your controller. 

The sample controller contains the following code:

```angular2
<?php

namespace App\Http\Controllers;

use Illuminate\Http\Request;
use Wink\WinkPost;

class BlogController extends Controller
{
    public function index()
    {
        $posts = WinkPost::with('tags')
            ->live()
            ->orderBy('publish_date', 'DESC')
            ->simplePaginate(10);
        return view('blog.index', [
            'posts' => $posts,
        ]);
    }

    public function show ($slug)
    {
        $post = WinkPost::live()->whereSlug($slug)->firstOrFail();

        return view('post.index', [
            'post' => $post
        ]);
    }
}
```
 
 This mean the `index()` method will retrieve 10 published blog posts per page with their associated tags, most recent first, and render them in the `blog.index` view. You will need to create that view and the associated route.
 
 The `show()` method in turn will retrieve a single published post corresponding to its slug and render it in the `post.index` view,  displaying an error message if it's not found.  You will need to create that view with the associated route,. 
 