### PR TITLE
Adding a reading duration to the post

### DIFF
--- a/src/Http/Controllers/PostsController.php
+++ b/src/Http/Controllers/PostsController.php
@@ -73,6 +73,7 @@ class PostsController
             'excerpt' => request('excerpt', ''),
             'slug' => request('slug'),
             'body' => request('body', ''),
+            'duration' => $this->readingDuration(request('body', '')),
             'published' => request('published'),
             'markdown' => request('markdown'),
             'author_id' => request('author_id'),
@@ -141,4 +142,18 @@ class PostsController
 
         $entry->delete();
     }
+
+    /**
+     * Return the time needed to read a post
+     * 
+     * @param  string  $text
+     * @return int
+     */
+    public function readingDuration(...$text)
+    {
+        $totalWords = str_word_count(implode(" ", $text));
+        $minutesToRead = round($totalWords / 200); // 200 is the average number of words which the user can read per minute.
+        return (int)max(1, $minutesToRead); // It will return at minimum one minute
+    }
+
 }

--- a/src/Migrations/2018_10_30_000000_create_tables.php
+++ b/src/Migrations/2018_10_30_000000_create_tables.php
@@ -35,6 +35,7 @@ class CreateTables extends Migration
             $table->string('title');
             $table->text('excerpt');
             $table->text('body');
+            $table->integer('duration');
             $table->boolean('published')->default(false);
             $table->dateTime('publish_date')->default('2018-10-10 00:00:00');
             $table->string('featured_image')->nullable();


### PR DESCRIPTION
**In most publishing platforms like Hashnode, Medium or Dev.io every single post have an estimated time for reading, So the user knows the time needed to complete the post. **