### PR TITLE
Adds property docblocks for the various Wink models

### DIFF
--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -18,7 +18,6 @@ use Illuminate\Database\Eloquent\Collection;
  * @property CarbonInterface $updated_at
  * @property CarbonInterface $created_at
  * @property array<mixed>|null $meta
- *
  * @property-read Collection<WinkPost> $posts
  */
 class WinkAuthor extends AbstractWinkModel implements Authenticatable

--- a/src/WinkAuthor.php
+++ b/src/WinkAuthor.php
@@ -2,8 +2,25 @@
 
 namespace Wink;
 
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Collection;
 
+/**
+ * @property string $id
+ * @property string $slug
+ * @property string $name
+ * @property string $email
+ * @property string $password
+ * @property string $bio
+ * @property string $avatar
+ * @property string|null $remember_token
+ * @property CarbonInterface $updated_at
+ * @property CarbonInterface $created_at
+ * @property array<mixed>|null $meta
+ *
+ * @property-read Collection<WinkPost> $posts
+ */
 class WinkAuthor extends AbstractWinkModel implements Authenticatable
 {
     /**

--- a/src/WinkPage.php
+++ b/src/WinkPage.php
@@ -2,6 +2,18 @@
 
 namespace Wink;
 
+use Carbon\CarbonInterface;
+
+/**
+ * @property string $id
+ * @property string $slug
+ * @property string $title
+ * @property-write string $body
+ * @property-read string $content
+ * @property CarbonInterface $updated_at
+ * @property CarbonInterface $created_at
+ * @property array<mixed>|null $meta
+ */
 class WinkPage extends AbstractWinkModel
 {
     /**
@@ -53,7 +65,7 @@ class WinkPage extends AbstractWinkModel
     /**
      * Get the renderable page content.
      *
-     * @return HtmlString
+     * @return string
      */
     public function getContentAttribute()
     {

--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -24,7 +24,6 @@ use League\CommonMark\GithubFlavoredMarkdownConverter;
  * @property CarbonInterface $created_at
  * @property array<mixed>|null $meta
  * @property bool $markdown
- *
  * @property-read WinkAuthor $author
  * @property-read Collection<WinkTag> $tags
  */
@@ -126,7 +125,7 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include published posts.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopePublished($query)
@@ -137,7 +136,7 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include drafts (unpublished posts).
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeDraft($query)
@@ -148,7 +147,7 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include posts whose publish date is in the past (or now).
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeLive($query)
@@ -159,7 +158,7 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include posts whose publish date is in the future.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeScheduled($query)
@@ -170,8 +169,8 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include posts whose publish date is before a given date.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $date
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  string  $date
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeBeforePublishDate($query, $date)
@@ -182,8 +181,8 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include posts whose publish date is after a given date.
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $date
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  string  $date
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeAfterPublishDate($query, $date)
@@ -194,8 +193,8 @@ class WinkPost extends AbstractWinkModel
     /**
      * Scope a query to only include posts that have a specific tag (by slug).
      *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $slug
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  string  $slug
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeTag($query, string $slug)
@@ -208,7 +207,7 @@ class WinkPost extends AbstractWinkModel
     /**
      * Prepare a date for array / JSON serialization.
      *
-     * @param \DateTimeInterface $date
+     * @param  \DateTimeInterface  $date
      * @return string
      */
     protected function serializeDate(DateTimeInterface $date)

--- a/src/WinkPost.php
+++ b/src/WinkPost.php
@@ -2,10 +2,32 @@
 
 namespace Wink;
 
+use Carbon\CarbonInterface;
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\HtmlString;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 
+/**
+ * @property string $id
+ * @property string $slug
+ * @property string $title
+ * @property string $excerpt
+ * @property-write string $body
+ * @property-read HtmlString|string $content
+ * @property bool $published
+ * @property CarbonInterface $publish_date
+ * @property string|null $featured_image
+ * @property string $featured_image_caption
+ * @property string $author_id
+ * @property CarbonInterface $updated_at
+ * @property CarbonInterface $created_at
+ * @property array<mixed>|null $meta
+ * @property bool $markdown
+ *
+ * @property-read WinkAuthor $author
+ * @property-read Collection<WinkTag> $tags
+ */
 class WinkPost extends AbstractWinkModel
 {
     /**
@@ -86,7 +108,7 @@ class WinkPost extends AbstractWinkModel
     /**
      * Get the renderable post content.
      *
-     * @return HtmlString
+     * @return HtmlString|string
      */
     public function getContentAttribute()
     {

--- a/src/WinkTag.php
+++ b/src/WinkTag.php
@@ -2,6 +2,19 @@
 
 namespace Wink;
 
+use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
+
+/**
+ * @property string $id
+ * @property string $slug
+ * @property string $name
+ * @property CarbonInterface $updated_at
+ * @property CarbonInterface $created_at
+ * @property array<mixed>|null $meta
+ *
+ * @property-read Collection<WinkPost> $posts
+ */
 class WinkTag extends AbstractWinkModel
 {
     /**

--- a/src/WinkTag.php
+++ b/src/WinkTag.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Collection;
  * @property CarbonInterface $updated_at
  * @property CarbonInterface $created_at
  * @property array<mixed>|null $meta
- *
  * @property-read Collection<WinkPost> $posts
  */
 class WinkTag extends AbstractWinkModel


### PR DESCRIPTION
Howdy!

First of all, thanks for the great package Mohamed; it really is a pleasure to work with. In the Pest in Practice series, I've been using Wink to build out the news.pestphp.com site. I use PhpStan for static analysis, and it currently complains because it doesn't understand the model attributes.

Rather than stub these files out, I thought it would be better just to contribute to Wink with the correct docblocks so that everybody can benefit. This also results in better IDE autocompletion for all Wink models.

Thanks for all the hard work in Open Source and Laravel.

Kind Regards,
Luke